### PR TITLE
fix: update runner PATH for pnpm v11 global bin directory

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -3,8 +3,8 @@ RUN apt-get update && apt-get install -y bash curl git jq sudo unzip
 RUN echo 'node ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 RUN corepack enable
 RUN corepack install --global pnpm@latest
-ENV PATH="/pnpm-bin:${PATH}"
 ENV PNPM_HOME="/pnpm-bin"
+ENV PATH="/pnpm-bin/bin:${PATH}"
 RUN mkdir /pnpm-bin && chown node:node /pnpm-bin
 USER node
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- pnpm v11 changed the global binary directory from `$PNPM_HOME` to `$PNPM_HOME/bin`
- The runner Dockerfile had `ENV PATH="/pnpm-bin:${PATH}"`, but pnpm v11.1.2 (installed via `corepack install --global pnpm@latest`) now expects `/pnpm-bin/bin` to be in PATH
- This caused every CI job to fail at the Docker build step with: `[ERROR] The configured global bin directory "/pnpm-bin/bin" is not in PATH`
- Fix: swap the `ENV` order and change PATH to `/pnpm-bin/bin` to match pnpm v11's layout

The CI has been failing on every daily run since 2026-05-06 (10 consecutive failures as of 2026-05-15).

## Root cause

```
#13 [8/8] RUN pnpm install --global http-server
#13 1.109 [ERROR] The configured global bin directory "/pnpm-bin/bin" is not in PATH
#13 ERROR: process "/bin/sh -c pnpm install --global http-server" did not complete successfully: exit code: 1
```

`corepack install --global pnpm@latest` resolved to **pnpm 11.1.2**, which enforces that `$PNPM_HOME/bin` is in `PATH` before running `pnpm install --global`.

## Change

```diff
-ENV PATH="/pnpm-bin:${PATH}"
 ENV PNPM_HOME="/pnpm-bin"
+ENV PATH="/pnpm-bin/bin:${PATH}"
```

## Test plan

- [ ] Docker build of `runner/` succeeds locally
- [ ] CI `Factory` workflow passes on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01BhQvTnqAx4nkECdLh8XShQ)_