### PR TITLE
[Factory autofix] Update Playwright screenshotter image to v1.60.0

### DIFF
--- a/screenshotter/Dockerfile
+++ b/screenshotter/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.49.0-jammy
-RUN npm install -g playwright@1.49.0
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
+RUN npm install -g playwright@1.60.0
 USER pwuser
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- **Screenshotter Dockerfile**: Updated `mcr.microsoft.com/playwright:v1.49.0-jammy` (returns 403 Forbidden — deprecated/removed) to `v1.60.0-jammy`, the latest available version on MCR.

## Root cause

The `build (fresh-astro-project)` CI job fails because the screenshotter Docker image build pulls `mcr.microsoft.com/playwright:v1.49.0-jammy`, which now returns HTTP 403 Forbidden. This is the same pattern as the previous autofix (v1.41.1 → v1.49.0 in PR #15).

## Test plan

- [ ] Trigger the `factory` workflow and verify the `build (fresh-astro-project)` job passes
- [ ] Confirm the screenshotter Docker image builds without 403 error

https://claude.ai/code/session_015JT7xTSDH5oZrDVFhqeGJr

---
_Generated by [Claude Code](https://claude.ai/code/session_015JT7xTSDH5oZrDVFhqeGJr)_