### PR TITLE
[Factory autofix] Fix fresh-vscode-web-extension Playwright browser and upload-result SHA retry

### DIFF
--- a/src/UploadResultAction.ts
+++ b/src/UploadResultAction.ts
@@ -50,7 +50,9 @@ export class UploadResultAction extends CommandLineAction {
           return
         } catch (e: any) {
           if (e.status === 422 && attempt < 2) {
-            console.log(`=> ${path} SHA conflict, retrying (attempt ${attempt + 1})`)
+            console.log(
+              `=> ${path} SHA conflict, retrying (attempt ${attempt + 1})`,
+            )
             await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)))
             continue
           }

--- a/src/UploadResultAction.ts
+++ b/src/UploadResultAction.ts
@@ -1,5 +1,4 @@
 import { CommandLineAction } from '@rushstack/ts-command-line'
-import { createHash } from 'crypto'
 import { existsSync, readFileSync } from 'fs'
 import { Octokit } from 'octokit'
 
@@ -23,34 +22,41 @@ export class UploadResultAction extends CommandLineAction {
       contents: Buffer,
       message: string,
     ) => {
-      const newSha = createHash('sha1').update(contents).digest('hex')
       const ptr = {
         owner: 'fresh-app',
         repo: 'results',
         path,
       }
-      const oldSha = await octokit.rest.repos
-        .getContent({ ...ptr })
-        .then((res) => ('sha' in res.data ? res.data.sha : undefined))
-        .catch((e: any) => (e.status === 404 ? undefined : Promise.reject(e)))
-      if (oldSha === newSha) {
-        console.log(`=> ${path} is up to date`)
-        return
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const oldSha = await octokit.rest.repos
+          .getContent({ ...ptr })
+          .then((res) => ('sha' in res.data ? res.data.sha : undefined))
+          .catch((e: any) => (e.status === 404 ? undefined : Promise.reject(e)))
+        try {
+          await octokit.rest.repos.createOrUpdateFileContents({
+            ...ptr,
+            ...(oldSha ? { sha: oldSha } : null),
+            message,
+            content: contents.toString('base64'),
+            author: {
+              name: 'dtinth-bot',
+              email: 'dtinth-bot@users.noreply.github.com',
+            },
+            committer: {
+              name: 'dtinth-bot',
+              email: 'dtinth-bot@users.noreply.github.com',
+            },
+          })
+          return
+        } catch (e: any) {
+          if (e.status === 422 && attempt < 2) {
+            console.log(`=> ${path} SHA conflict, retrying (attempt ${attempt + 1})`)
+            await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)))
+            continue
+          }
+          throw e
+        }
       }
-      await octokit.rest.repos.createOrUpdateFileContents({
-        ...ptr,
-        ...(oldSha ? { sha: oldSha } : null),
-        message,
-        content: contents.toString('base64'),
-        author: {
-          name: 'dtinth-bot',
-          email: 'dtinth-bot@users.noreply.github.com',
-        },
-        committer: {
-          name: 'dtinth-bot',
-          email: 'dtinth-bot@users.noreply.github.com',
-        },
-      })
     }
     await updateFile(
       result.generator + '.json',

--- a/src/generators/fresh-vscode-web-extension.ts
+++ b/src/generators/fresh-vscode-web-extension.ts
@@ -14,6 +14,7 @@ export default defineGenerator({
     'mv yeoman_temp/fresh-extension fresh-app',
     'rm -rf yeoman_temp',
     'test -f fresh-app/package.json',
+    'fresh-app/node_modules/.bin/playwright install chromium',
   ].join('\n'),
   displayedCommand: 'yo code --extensionType=web',
   description: 'Fresh VS Code web extension',


### PR DESCRIPTION
## Summary

Two jobs failed in the 2026-06-16 factory run:

- `build (fresh-vscode-web-extension)` — Playwright Chromium browser missing
- `build (fresh-vite-app-preact)` — `upload-result` SHA mismatch 422 error

### fresh-vscode-web-extension fix

`@vscode/test-web 0.0.80` requires Playwright's Chromium binary (`chromium_headless_shell-1223`) to launch `--headless`. It was not installed, causing:

```
Error opening browser: browserType.launch: Executable doesn't exist at
/home/node/.cache/ms-playwright/chromium_headless_shell-1223/chrome-headless-shell-linux64/chrome-headless-shell
```

The `yo code` generator runs `npm install` during scaffold, so `fresh-app/node_modules/.bin/playwright` is available with the exact Playwright version that `@vscode/test-web` depends on. Adding `fresh-app/node_modules/.bin/playwright install chromium` to the end of the generator command downloads the correct browser binary before the `serverCommand` runs.

### UploadResultAction fix

The `upload-result` step for `fresh-vite-app-preact` failed with a GitHub API 422:

```
Error: is at a2120f23665829bff7ebc534a18cad0db8d21dd2 but expected 740138fc43c016b2d47caa4d112740f4faacb0cf
```

This is a race condition: 35 jobs all write to `fresh-app/results` concurrently, and the blob SHA can change between the `getContent` (GET) and `createOrUpdateFileContents` (PUT) calls. Fix: retry up to 3 times, re-fetching the current SHA on each 422.

Also removed the broken skip-optimization that compared a plain SHA1 of contents against GitHub's git-blob SHA1 (they're never equal, making the check dead code).

## Test plan

- [ ] Trigger the `factory` workflow and verify `build (fresh-vscode-web-extension)` passes
- [ ] Verify `vscode-test-web --headless` server starts successfully and screenshotter captures the extension
- [ ] Confirm `upload-result` retries gracefully on SHA conflicts instead of failing

🤖 Generated with [Claude Code](https://claude.ai/code/session_01SWo4AoHrkBdDJD3v8RxmcL)

https://claude.ai/code/session_01SWo4AoHrkBdDJD3v8RxmcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWo4AoHrkBdDJD3v8RxmcL)_