### PR TITLE
[Factory autofix] Fix fresh-remix-spa: replace removed minimal template with default + SPA mode

### DIFF
--- a/src/generators/fresh-remix-spa.ts
+++ b/src/generators/fresh-remix-spa.ts
@@ -2,17 +2,17 @@ import { defineGenerator } from '../defineGenerator'
 
 export default defineGenerator({
   command: [
-    'pnpm create react-router fresh-app --no-git-init --no-install --template remix-run/react-router-templates/minimal',
+    'pnpm create react-router fresh-app --no-git-init --no-install --template remix-run/react-router-templates/default',
     'cd fresh-app',
+    'sed -i "s/ssr: true/ssr: false/" react-router.config.ts',
     'corepack use pnpm@latest || (pnpm approve-builds --all && corepack use pnpm@latest)',
     'pnpm build',
   ].join('\n'),
   displayedCommand:
-    'pnpm create react-router --template remix-run/react-router-templates/minimal',
-  description: 'Fresh React Router minimal app',
-  longDescription: 'Fresh React Router minimal app (Remix successor)',
+    'pnpm create react-router --template remix-run/react-router-templates/default',
+  description: 'Fresh React Router SPA app',
+  longDescription: 'Fresh React Router Single Page Application (SPA) app (Remix successor)',
   frameworkUrl: 'https://reactrouter.com/',
-  frameworkDocumentationUrl:
-    'https://reactrouter.com/start/framework/installation',
+  frameworkDocumentationUrl: 'https://reactrouter.com/how-to/spa',
   staticOutputDirectory: 'build/client',
 })

--- a/src/generators/fresh-remix-spa.ts
+++ b/src/generators/fresh-remix-spa.ts
@@ -11,7 +11,8 @@ export default defineGenerator({
   displayedCommand:
     'pnpm create react-router --template remix-run/react-router-templates/default',
   description: 'Fresh React Router SPA app',
-  longDescription: 'Fresh React Router Single Page Application (SPA) app (Remix successor)',
+  longDescription:
+    'Fresh React Router Single Page Application (SPA) app (Remix successor)',
   frameworkUrl: 'https://reactrouter.com/',
   frameworkDocumentationUrl: 'https://reactrouter.com/how-to/spa',
   staticOutputDirectory: 'build/client',


### PR DESCRIPTION
## Summary

- **Root cause**: The `build (fresh-remix-spa)` CI job fails because `remix-run/react-router-templates/minimal` has been removed from the upstream repo: *"Oh no! The path 'minimal' was not found in this GitHub repo."*
- **Fix**: Switch to `--template remix-run/react-router-templates/default` (the only stable template available), then patch `react-router.config.ts` via `sed -i "s/ssr: true/ssr: false/"` to enable SPA mode — preserving the original intent of the generator as a static/client-only build with output in `build/client`.

## Available templates (as of 2026-06-19)

- `default` — SSR, TypeScript, TailwindCSS, Docker  
- `node-custom-server` — custom server  
- `unstable_rsc-*` — experimental  

The `minimal` template is gone; `default` is the only stable non-experimental option.

## Test plan

- [ ] Trigger the `factory` workflow and verify `build (fresh-remix-spa)` passes
- [ ] Confirm `pnpm build` completes and `build/client` contains static SPA output

🤖 Generated with [Claude Code](https://claude.ai/code/session_01FSzan3hZpgwaHNu6nSUSYF)

https://claude.ai/code/session_01FSzan3hZpgwaHNu6nSUSYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzan3hZpgwaHNu6nSUSYF)_