### PR TITLE
[Factory autofix] Fix fresh-remix-spa: update template from minimal to default

### DIFF
--- a/src/generators/fresh-remix-spa.ts
+++ b/src/generators/fresh-remix-spa.ts
@@ -2,13 +2,13 @@ import { defineGenerator } from '../defineGenerator'
 
 export default defineGenerator({
   command: [
-    'pnpm create react-router fresh-app --no-git-init --no-install --template remix-run/react-router-templates/minimal',
+    'pnpm create react-router fresh-app --no-git-init --no-install --template remix-run/react-router-templates/default',
     'cd fresh-app',
     'corepack use pnpm@latest || (pnpm approve-builds --all && corepack use pnpm@latest)',
     'pnpm build',
   ].join('\n'),
   displayedCommand:
-    'pnpm create react-router --template remix-run/react-router-templates/minimal',
+    'pnpm create react-router --template remix-run/react-router-templates/default',
   description: 'Fresh React Router minimal app',
   longDescription: 'Fresh React Router minimal app (Remix successor)',
   frameworkUrl: 'https://reactrouter.com/',


### PR DESCRIPTION
## Summary

- The `fresh-remix-spa` generator was failing because `remix-run/react-router-templates/minimal` no longer exists in the upstream repo
- The `minimal` template has been replaced with `default` in the `remix-run/react-router-templates` repository
- Updated both the `command` and `displayedCommand` fields to use the `default` template

## Root Cause

CI failure in the `build (fresh-remix-spa)` job ([run #27857890570](https://github.com/fresh-app/factory/actions/runs/27857890570)):
```
▲  Oh no! The path "minimal" was not found in this GitHub repo.
```

## Fix

Changed `--template remix-run/react-router-templates/minimal` → `--template remix-run/react-router-templates/default` in `src/generators/fresh-remix-spa.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNEumo9JJgQYGjRkLfF2uH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNEumo9JJgQYGjRkLfF2uH)_