### PR TITLE
[Factory autofix] Fix fresh-remix-spa: replace removed minimal template

### DIFF
--- a/src/generators/fresh-remix-spa.ts
+++ b/src/generators/fresh-remix-spa.ts
@@ -2,13 +2,14 @@ import { defineGenerator } from '../defineGenerator'
 
 export default defineGenerator({
   command: [
-    'pnpm create react-router fresh-app --no-git-init --no-install --template remix-run/react-router-templates/minimal',
+    'pnpm create react-router fresh-app --no-git-init --no-install --template remix-run/react-router-templates/default',
     'cd fresh-app',
+    'sed -i "s/ssr: true/ssr: false/" react-router.config.ts',
     'corepack use pnpm@latest || (pnpm approve-builds --all && corepack use pnpm@latest)',
     'pnpm build',
   ].join('\n'),
   displayedCommand:
-    'pnpm create react-router --template remix-run/react-router-templates/minimal',
+    'pnpm create react-router --template remix-run/react-router-templates/default',
   description: 'Fresh React Router minimal app',
   longDescription: 'Fresh React Router minimal app (Remix successor)',
   frameworkUrl: 'https://reactrouter.com/',


### PR DESCRIPTION
## Summary

- The `remix-run/react-router-templates/minimal` template was removed from the upstream repo, causing the `fresh-remix-spa` build to fail with: _"Oh no! The path 'minimal' was not found in this GitHub repo."_
- Switch to the `default` template and patch `react-router.config.ts` to set `ssr: false` (SPA mode), preserving the original intent of a static client-side-only build to `build/client`
- This has been failing on `main` daily since 2026-06-19

## Test plan

- [ ] `build (fresh-remix-spa)` job passes in CI on this PR
- [ ] Other generator jobs remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4VvyiK6D9GkRS4QDYJeLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4VvyiK6D9GkRS4QDYJeLs)_