### PR TITLE
[Factory autofix] Retry upload-result on GitHub SHA conflicts

### DIFF
--- a/src/UploadResultAction.ts
+++ b/src/UploadResultAction.ts
@@ -51,7 +51,9 @@ export class UploadResultAction extends CommandLineAction {
           return
         } catch (e: any) {
           if (e.status === 422 && attempt < maxAttempts) {
-            console.log(`=> ${path} SHA conflict, retrying (attempt ${attempt})`)
+            console.log(
+              `=> ${path} SHA conflict, retrying (attempt ${attempt})`,
+            )
             await new Promise((r) => setTimeout(r, 1000 * attempt))
             continue
           }

--- a/src/UploadResultAction.ts
+++ b/src/UploadResultAction.ts
@@ -1,5 +1,4 @@
 import { CommandLineAction } from '@rushstack/ts-command-line'
-import { createHash } from 'crypto'
 import { existsSync, readFileSync } from 'fs'
 import { Octokit } from 'octokit'
 
@@ -23,34 +22,42 @@ export class UploadResultAction extends CommandLineAction {
       contents: Buffer,
       message: string,
     ) => {
-      const newSha = createHash('sha1').update(contents).digest('hex')
       const ptr = {
         owner: 'fresh-app',
         repo: 'results',
         path,
       }
-      const oldSha = await octokit.rest.repos
-        .getContent({ ...ptr })
-        .then((res) => ('sha' in res.data ? res.data.sha : undefined))
-        .catch((e: any) => (e.status === 404 ? undefined : Promise.reject(e)))
-      if (oldSha === newSha) {
-        console.log(`=> ${path} is up to date`)
-        return
+      const maxAttempts = 3
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const oldSha = await octokit.rest.repos
+          .getContent({ ...ptr })
+          .then((res) => ('sha' in res.data ? res.data.sha : undefined))
+          .catch((e: any) => (e.status === 404 ? undefined : Promise.reject(e)))
+        try {
+          await octokit.rest.repos.createOrUpdateFileContents({
+            ...ptr,
+            ...(oldSha ? { sha: oldSha } : null),
+            message,
+            content: contents.toString('base64'),
+            author: {
+              name: 'dtinth-bot',
+              email: 'dtinth-bot@users.noreply.github.com',
+            },
+            committer: {
+              name: 'dtinth-bot',
+              email: 'dtinth-bot@users.noreply.github.com',
+            },
+          })
+          return
+        } catch (e: any) {
+          if (e.status === 422 && attempt < maxAttempts) {
+            console.log(`=> ${path} SHA conflict, retrying (attempt ${attempt})`)
+            await new Promise((r) => setTimeout(r, 1000 * attempt))
+            continue
+          }
+          throw e
+        }
       }
-      await octokit.rest.repos.createOrUpdateFileContents({
-        ...ptr,
-        ...(oldSha ? { sha: oldSha } : null),
-        message,
-        content: contents.toString('base64'),
-        author: {
-          name: 'dtinth-bot',
-          email: 'dtinth-bot@users.noreply.github.com',
-        },
-        committer: {
-          name: 'dtinth-bot',
-          email: 'dtinth-bot@users.noreply.github.com',
-        },
-      })
     }
     await updateFile(
       result.generator + '.json',

--- a/src/UploadResultAction.ts
+++ b/src/UploadResultAction.ts
@@ -50,7 +50,7 @@ export class UploadResultAction extends CommandLineAction {
           })
           return
         } catch (e: any) {
-          if (e.status === 422 && attempt < maxAttempts) {
+          if ((e.status === 409 || e.status === 422) && attempt < maxAttempts) {
             console.log(
               `=> ${path} SHA conflict, retrying (attempt ${attempt})`,
             )


### PR DESCRIPTION
## Summary

- The `build (fresh-remix-app)` job failed in the [2026-07-10 scheduled factory run](https://github.com/fresh-app/factory/actions/runs/29064616061) (job [86273422395](https://github.com/fresh-app/factory/actions/runs/29064616061/job/86273422395)) at the `pnpm factory upload-result` step, with a GitHub API 422 error from `createOrUpdateFileContents`:
  ```
  Error: is at 67017c1be6552ddaf203e5626dad11fe8bd24e7b but expected 8c379ecc0547d6ca63feb1807429d66fa83ba5ab
  ```
- **Root cause**: race condition — `fresh-app/results`' blob SHA for the target file can change between the `getContent` (GET) and `createOrUpdateFileContents` (PUT) calls, causing GitHub to reject the PUT with a stale-SHA 422.
- **Fix**: retry the update up to 3 times, re-fetching the current SHA on each 422 conflict instead of failing the whole job. Also dropped the dead `createHash('sha1')` "up to date" pre-check, since a plain SHA1 of the raw content is never equal to GitHub's git-blob SHA1 (git blobs are hashed with a `"blob <size>\0"` prefix), so that comparison could never short-circuit.

## Test plan

- [x] `pnpm exec tsc --noEmit -p .` passes
- [ ] Trigger the `factory` workflow and verify `upload-result` no longer fails on SHA conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgxYnCRji2GfyEXvuPB2Lb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgxYnCRji2GfyEXvuPB2Lb)_