### PR TITLE
[Factory autofix] Install @typescript/native-preview for vite:library pack

### DIFF
--- a/src/generators/fresh-viteplus-lib.ts
+++ b/src/generators/fresh-viteplus-lib.ts
@@ -7,6 +7,7 @@ export default defineGenerator({
     'vp create vite:library --directory fresh-app --no-interactive',
     'cd fresh-app',
     'vp install',
+    'pnpm add -D @typescript/native-preview',
     'vp pack',
   ].join('\n'),
   displayedCommand: 'vp create vite:library',


### PR DESCRIPTION
## Summary

- The `build (fresh-viteplus-lib)` job has failed on **every** scheduled `factory` run since at least 2026-07-12 (e.g. [2026-07-16 run](https://github.com/fresh-app/factory/actions/runs/29465565273), job [87517872056](https://github.com/fresh-app/factory/actions/runs/29465565273/job/87517872056)) at the `vp pack` step:
  ```
  Error: Cannot find package '@typescript/native-preview' imported from
  /workspace/fresh-app/node_modules/.pnpm/@voidzero-dev+vite-plus-core@0.2.4_.../node_modules/@voidzero-dev/vite-plus-core/dist/tsdown/dist-CqbVlnVq.js
  ```
- **Root cause**: the scaffolded `vite:library` project resolves `typescript` to `7.0.2`. vite-plus-core's `dts` plugin detects this and tries to build via the native `tsgo` compiler, resolving the binary from `@typescript/native-preview` in `node_modules` — but that package is never actually installed, since it's not a declared dependency of the scaffolded project (`typescript` itself is only an optional peer dependency of `@voidzero-dev/vite-plus-core`).
- Other Vite+ generators (`fresh-viteplus-app`, `fresh-viteplus-monorepo`) are unaffected because they call `vp build`, not `vp pack`, so the dts/tsgo path is never hit.
- **Fix**: explicitly `pnpm add -D @typescript/native-preview` after `vp install` and before `vp pack`, so the required native compiler binary is present. This follows the same pattern already used by `fresh-vitepress-site` (adding a dependency missing from the scaffold before building).

## Test plan

- [x] `pnpm exec tsc --noEmit -p .` passes
- [ ] Trigger the `factory` workflow and verify `build (fresh-viteplus-lib)` no longer fails at `vp pack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3M3Y7duyx3HQSSjnXawPE


---
_Generated by [Claude Code](https://claude.ai/code/session_01F3M3Y7duyx3HQSSjnXawPE)_