### PR TITLE
[Factory autofix] Fix fresh-vscode-web-extension: allow browser-chromium build script on global install

### DIFF
--- a/src/generators/fresh-vscode-web-extension.ts
+++ b/src/generators/fresh-vscode-web-extension.ts
@@ -8,7 +8,7 @@ export default defineGenerator({
     'pnpm init',
     'jq "del(.devEngines)" package.json > package.json.tmp && mv package.json.tmp package.json',
     'pnpm add yo generator-code || (pnpm approve-builds --all && pnpm add yo generator-code)',
-    'pnpm install --global @vscode/test-web',
+    'pnpm add --global --allow-build=@playwright/browser-chromium @vscode/test-web',
     'pnpm exec yo code --quick --extensionType=web --gitInit=false fresh-extension',
     'cd ..',
     'mv yeoman_temp/fresh-extension fresh-app',


### PR DESCRIPTION
## Summary

- The `build (fresh-vscode-web-extension)` job failed in the [2026-07-25 scheduled factory run](https://github.com/fresh-app/factory/actions/runs/30139747751) (job [89630597792](https://github.com/fresh-app/factory/actions/runs/30139747751/job/89630597792)) at the `vscode-test-web --headless` server startup step:
  ```
  Error opening browser: browserType.launch: Executable doesn't exist at
  /home/node/.cache/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell
  ```
  The uncaught exception crashed the `vscode-test-web` process (which had already printed `Listening on http://localhost:3000`), which then made the subsequent port-availability wait fail with `Timed out waiting for: tcp:localhost:3000`.
- **Root cause**: `@vscode/test-web` depends on [`@playwright/browser-chromium`](https://www.npmjs.com/package/@playwright/browser-chromium), whose `"install": "node install.js"` lifecycle script is what actually downloads the Chromium binary. Under pnpm v10+'s default script-blocking security policy, lifecycle/build scripts of dependencies are ignored unless explicitly allowed. For **global** installs on pnpm v11 (isolated global packages), `pnpm approve-builds --global`/`-g` [is no longer supported](https://pnpm.io/cli/approve-builds) — the documented replacement is `pnpm add -g --allow-build=<pkg> <pkg>`.
  - Without the browser binary present, `vscode-test-web --headless` (which the `serverCommand` runs) crashes trying to open it.
  - This is intermittent because whether the ignored build actually breaks things downstream only surfaces once the browser is actually needed at runtime — the `pnpm add`/`install` step itself succeeds either way.
- **Fix**: switch the global install from `pnpm install --global @vscode/test-web` to `pnpm add --global --allow-build=@playwright/browser-chromium @vscode/test-web`, so the Chromium download actually runs during install. This mirrors the existing `pnpm approve-builds --all` fallback used one line above for `yo generator-code`'s blocked `postinstall` script — same underlying pnpm 10+ build-script-allowlisting mechanism, just using the flag required for global installs.

## Test plan

- [x] `pnpm exec tsc --noEmit -p .` passes
- [ ] Trigger the `factory` workflow (this PR itself runs it via the `pull_request` trigger) and verify `build (fresh-vscode-web-extension)` no longer fails opening the browser

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_015sqzLeZeqU7p1XmdadAC5S

---
_Generated by [Claude Code](https://claude.ai/code/session_015sqzLeZeqU7p1XmdadAC5S)_